### PR TITLE
Use mailto if available

### DIFF
--- a/Support/bin/showinfo
+++ b/Support/bin/showinfo
@@ -4,9 +4,17 @@
 require "uri"
 uris = URI.extract(ENV['MM_LIST_INFO'])
 
-uris.each do |url|
-    if url.start_with?('http')
-       cmd = "open " + url
-       system(cmd)
-    end
+nothingfound = true
+
+uris.each do |url| url.start_with?("mailto:")
+  system("open " + url)
+  nothingfound = false
 end
+
+if nothingfound then
+  uris.each do |url| url.start_with?("http")
+    system("open " + url)
+  end
+end
+
+


### PR DESCRIPTION
Why:

 * when i'm not behind vpn I cannot visit the http urls for unsuscribe.
   would be great if unsubscribe would honor mailto: if they are available.

This change addreses the need by:

 * look for mailto before http and then just use it to open corresponding mailto.