### PR TITLE
Replace address table with JSON syntax version

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,4 +1,26 @@
-# Features
+# Enhancements
+
+This "Enhanced MailMan Bundle" is a fork of the MailMan bundle
+included with MailMate.  It is as the original, however, in order to
+handle lists whose delivery includes address rewriting, it allows the
+user to save a `.mailman-addresses` file in their home directory,
+which is (for now) a perl hash mapping delivery addresses to sender
+addresses.  That way, when one receives email addressed to
+`foobar-list-owner@hosting.com` one can rewrite the address to an
+address the mailman instance will accept.
+
+Currently this is only implemented for the "Reject" messages, since as
+a moderator, I have found my task is almost solely rejection.
+
+## To do:
+
+* Replace the use of a perl literal with a config file, which will be
+  safer, but needs to be handled without forcing dependencies on the
+  user.
+
+* Extend the address rewriting to acceptance emails.
+
+# Original Features
 
 This bundle groks the `List-*` headers used by MailMan based systems.
 

--- a/Support/bin/approve
+++ b/Support/bin/approve
@@ -5,11 +5,25 @@ ACTION=`defaults read com.freron.MailMate MmMailManCommandAction 2>/dev/null`
 if [ -z "${ACTION}" ]; then
 	ACTION="openMessage"
 fi
+if [ ! -z ${MM_DEBUG+x} ] && [ $MM_DEBUG ]
+then
+    echo "MailMan accept command";
+    echo "MM_TO is ${MM_TO}, PASSWORD before request is ${PASSWORD}, MM_IDENTIFIER is ${MM_IDENTIFIER}" >> /tmp/MailMan.log
+fi
+
 
 # If no password then ask for one
 if [ -z "${PASSWORD}" ]; then
 	PASSWORD=`"${MM_BUNDLE_SUPPORT}/bin/set_password"`
 fi
+
+export MM_ADDRESS=`${MM_BUNDLE_SUPPORT}/bin/table_lookup ${MM_TO}`
+if [ ! -z ${MM_DEBUG+x} ] && [ $MM_DEBUG ]
+then
+    echo "MM_ADDRESS is ${MM_ADDRESS}" >> /tmp/MailMan.log
+    echo "After request, PASSWORD = ${PASSWORD}." >> /tmp/MailMan.log
+fi
+
 
 # If password has been found then create the reply
 if [ -n "${PASSWORD}" ]; then

--- a/Support/bin/reject
+++ b/Support/bin/reject
@@ -30,9 +30,9 @@ cat << END
 			resultActions = (
 				{
 					type = "${ACTION}";
-				};
+				}
 			);
-		};
+		},
 	);
 }
 END

--- a/Support/bin/reject
+++ b/Support/bin/reject
@@ -4,6 +4,17 @@ ACTION=`defaults read com.freron.MailMate MmMailManCommandAction 2>/dev/null`
 if [ -z "${ACTION}" ]; then
 	ACTION="openMessage"
 fi
+if [ ! -z ${MM_DEBUG+x} ] && [ $MM_DEBUG ]
+then
+    echo "MM_TO is ${MM_TO}" >> /tmp/MailMan.log
+fi
+export MM_ADDRESS=`${MM_BUNDLE_SUPPORT}/bin/table_lookup ${MM_TO}`
+if [ ! -z ${MM_DEBUG+x} ] && [ $MM_DEBUG ]
+then
+    echo "MM_ADDRESS is ${MM_ADDRESS}" >> /tmp/MailMan.log
+    echo "ACTION = ${ACTION}." >> /tmp/MailMan.log
+fi
+
 
 cat << END
 { actions = (
@@ -13,14 +24,16 @@ cat << END
 			headers = {
 				"#posting-style" = "top";
 				"#signature" = "";
-				"from" = "${MM_TO}";
+				"from" = "${MM_ADDRESS}";
+                                "tags" = "Don'tSave";
 			};
 			resultActions = (
 				{
 					type = "${ACTION}";
-				}
+				};
 			);
-		},
+		};
 	);
 }
 END
+

--- a/Support/bin/reject
+++ b/Support/bin/reject
@@ -3,6 +3,7 @@
 ACTION=`defaults read com.freron.MailMate MmMailManCommandAction 2>/dev/null`
 if [ -z "${ACTION}" ]; then
 	ACTION="openMessage"
+        # ACTION="sendMessage" # we don't need to do anything to the message
 fi
 if [ ! -z ${MM_DEBUG+x} ] && [ $MM_DEBUG ]
 then

--- a/Support/bin/table_lookup
+++ b/Support/bin/table_lookup
@@ -1,0 +1,47 @@
+#! /usr/bin/env perl
+
+my $tableFilename = "$ENV{HOME}/.mailman-addresses";
+my $logfile;
+if ( $ENV{"DEBUG_MM"} ) {
+  $logfile = "/tmp/MailMan.log";
+} else {
+  $logfile = "/dev/null";
+}
+open(LOG, ">>$logfile");
+local $SIG{__DIE__} = sub {
+    my ($message) = @_;
+    print LOG "$message\n";
+};
+my %table;
+{
+  local $/;           # enable "slurp" mode
+  open(FH, "< $tableFilename") or die "Unable to open table file $tableFilename $!";
+  local $raw = <FH>;
+  close FH;
+#  print "$raw\n";
+  %table = %{eval $raw};
+}
+
+{
+  my @keys = sort(keys(%table));
+  print LOG "@keys\n";
+
+  if ( $ARGV[0] eq $keys[0] ) {
+    print LOG "$ARGV[0] matches a key."
+  } elsif ( $ARGV[0] ne $keys[0] ) {
+    print LOG "Surprisingly $ARGV[0] is not equal to $keys[0]\n";
+  }
+
+  foreach my $key (@keys) {
+    print LOG "$key\t$table{$key}\n";
+  }
+}
+
+my $INPUT_ADDRESS = $ARGV[0];
+chomp $INPUT_ADDRESS;
+#print "$INPUT_ADDRESS\n";
+my $entry = $table{"$INPUT_ADDRESS"};
+die "Unable to find entry for $INPUT_ADDRESS in $tableFilename" unless $entry;
+print LOG "Translating to $entry\n";
+close FH;
+print "$entry\n";

--- a/info.plist
+++ b/info.plist
@@ -9,8 +9,8 @@
 	<key>description</key>
 	<string>Commands for the MailMan mailing list software.</string>
 	<key>name</key>
-	<string>MailMan</string>
+	<string>Enhanced MailMan</string>
 	<key>uuid</key>
-	<string>5ED82AEE-926C-476F-A4D6-FA6E1E89F246</string>
+        <string>EC81B9E9-4AAF-4342-8A15-761027EA5E57</string>
 </dict>
 </plist>


### PR DESCRIPTION
Need to be able to choose the sending address appropriate to the mailing list.

There was a facility for doing this in the original bundle, but I couldn't figure out how to make it work, because there is no example of the syntax.  So I thought changing to JSON syntax might be easier.